### PR TITLE
client.creat() function is missing an "e", no?

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -204,6 +204,7 @@ ZKClient.prototype.creat = function creat(p, options, callback) {
         });
 };
 
+ZKClient.prototype.create = ZKClient.prototype.creat;
 
 ZKClient.prototype.get = function get(p, callback) {
         assertString('path', p);


### PR DESCRIPTION
makes more sense to me to either rename it or alias it
