### PR TITLE
Fix #8 Error not correctly catched in onChildren method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -612,7 +612,7 @@ ZKClient.prototype.watch = function watch(p, options, callback) {
                 };
 
                 function onChildren(rc2, msg2, children) {
-                        if (rc !== 0) {
+                        if (rc2 !== 0) {
                                 log.trace({
                                         path: _p,
                                         rc: rc2,


### PR DESCRIPTION
This error is very serious.
Indeed, the error is not catched and an event children is emitted and can create a side effect.
