### PR TITLE
Add optional prefix to election znodes.

### DIFF
--- a/lib/election.js
+++ b/lib/election.js
@@ -34,8 +34,9 @@ function Election(options) {
         this.client = options.client;
         this.data = JSON.stringify(options.object);
         this.log = options.log || this.client.log;
-        this.path = path.normalize(options.path) + '-';
-        this.parent = path.dirname(this.path);
+        this.parent = path.normalize(options.path);
+        // optional pathPrefix of the znode
+        this.pathPrefix = options.pathPrefix;
         this.znode = null;
 }
 util.inherits(Election, EventEmitter);
@@ -79,7 +80,7 @@ Election.prototype.getLeader = function getLeader(callback) {
                                                 nodes: nodes,
                                                 obj: obj
                                         }, 'election.getLeader: done');
-                                        nodes.splice();
+                                        nodes.shift();
                                         callback(null, l, obj, nodes);
                                 }
                         });
@@ -95,7 +96,12 @@ Election.prototype.isLeader = function isLeader(callback) {
                 if (err) {
                         callback(err);
                 } else {
-                        callback(null, (leader === self.znode), obj, nodes);
+                        var isLeader = (leader === self.znode);
+                        if (isLeader) {
+                                callback(null, isLeader, nodes);
+                        } else {
+                                callback(null, isLeader, obj);
+                        }
                 }
         });
 };
@@ -177,7 +183,14 @@ Election.prototype.vote = function vote(callback) {
                                 flags: ['ephemeral', 'sequence'],
                                 data: self.data
                         };
-                        client.create(self.path, opts, function (err, p) {
+                        var _path;
+                        if (self.pathPrefix) {
+                                _path = self.parent + '/' +
+                                        self.pathPrefix + '-';
+                        } else {
+                                var _path = self.parent + '/-';
+                        }
+                        client.create(_path, opts, function (err, p) {
                                 if (err) {
                                         log.trace({
                                                 parent: self.parent,
@@ -277,6 +290,18 @@ Election.prototype.watch = function watch(callback) {
         });
 };
 
+
+
+///--- Exports
+
+module.exports = {
+        Election: Election
+};
+
+
+
+///--- Privates
+
 /**
  * Compares two lock paths.
  * @param {string} a the lock path to compare.
@@ -290,9 +315,3 @@ function compare(a, b) {
 
   return seqA - seqB;
 }
-
-///--- Exports
-
-module.exports = {
-        Election: Election
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,8 @@ module.exports = {
                         client: options.client,
                         log: options.log,
                         object: options.object || {},
-                        path: options.path
+                        path: options.path,
+                        pathPrefix: options.pathPrefix
                 };
 
                 return (new Election(opts));

--- a/test/election.test.js
+++ b/test/election.test.js
@@ -19,7 +19,7 @@ var test = helper.test;
 
 var LOG = helper.createLogger('election.test.js');
 var DIR_PATH = '/' + uuid().substr(0, 7);
-var PATH = DIR_PATH + '/' + uuid().substr(0, 7);
+var PATH = uuid().substr(0, 7);
 var ZK;
 
 
@@ -111,7 +111,79 @@ test('election', function (t) {
         for (var i = 0; i < 3; i++) {
                 voters.push(zk.createElection({
                         client: ZK,
-                        path: PATH,
+                        path: DIR_PATH,
+                        log: LOG,
+                        object: {
+                                node: i
+                        }
+                }));
+        }
+
+        var leaderIndex;
+        voters.forEach(function (v, index) {
+                v.vote(function (err, isLeader) {
+                        t.ifError(err);
+                        if (isLeader) {
+                                t.equal(leader, null);
+                                leader = voters[index];
+                                leaderIndex = index;
+                        }
+
+                        if (++ready === 3) {
+                                t.notEqual(leader, null);
+                                voters.splice(leaderIndex, 1);
+                                watch();
+                        }
+                });
+        });
+});
+
+
+test('election with prefix', function (t) {
+        var leader = null;
+        var ready = 0;
+        var voters = [];
+
+        function watch() {
+                var watching = 0;
+                voters.forEach(function (v) {
+                        v.watch(function (err) {
+                                t.ifError(err);
+                                if (++watching === voters.length)
+                                        newLeader();
+                        });
+                });
+        }
+
+        function newLeader() {
+                // The logic below acts to have leaders commit seppuku
+                // in order
+                var newLeaderSeen = 0;
+                var stopped = 0;
+                voters.forEach(function (v) {
+                        v.on('leader', function () {
+                                v.on('close', function () {
+                                        if (++stopped === voters.length) {
+                                                t.equal(newLeaderSeen, 1);
+                                                t.end();
+                                        }
+                                });
+                                v.stop();
+                        });
+
+                        v.on('newLeader', function (l) {
+                                newLeaderSeen++;
+                                t.ok(l);
+                        });
+                });
+                leader.stop();
+        }
+
+        for (var i = 0; i < 3; i++) {
+                voters.push(zk.createElection({
+                        client: ZK,
+                        path: DIR_PATH,
+                        pathPrefix: PATH,
                         log: LOG,
                         object: {
                                 node: i


### PR DESCRIPTION
This can be used to inline data (such as an url) directly to the znode path, which means it's not necessary to make another request to zookeeper to fetch the data contained in the znode.
