### PR TITLE
Updates dependencies to get yunong/node-zookeeper/pull/2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
                 "bunyan": "0.18.2",
                 "node-uuid": "1.4.0",
                 "vasync": "1.3.3",
-                "zookeeper": "git://github.com/yunong/node-zookeeper.git#3a0545d"
+                "zookeeper": "git://github.com/yunong/node-zookeeper.git#5826464f87a78292918920bf4aca1dfd8b4f8f46"
         },
         "devDependencies": {
                 "cover": "0.2.8",


### PR DESCRIPTION
[yunong/node-zookeeper/pull/2](https://github.com/yunong/node-zookeeper/pull/2) cleans up the zookeeper client build/tmp directory, reducing installed size to &lt;4MB from &gt;60MB.
