### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
                 "node-uuid": "1.4.0",
                 "once": "1.1.1",
                 "vasync": "1.3.3",
-                "zookeeper": "3.4.6"
+                "zookeeper": "git://github.com/yfinkelstein/node-zookeeper.git"
         },
         "devDependencies": {
                 "cover": "0.2.8",


### PR DESCRIPTION
In trying to install the latest version of zkplus with 'npm install zkplus', I get the following error:

/usr/local/lib/node_modules/npm/node_modules/graceful-fs/polyfills.js:8
    cwd = origCwd.call(process)
                  ^
Error: ENOENT, no such file or directory
    at process.cwd (/usr/local/lib/node_modules/npm/node_modules/graceful-fs/polyfills.js:8:19)
    at errorMessage (/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js:119:28)
    at issueMessage (/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js:125:3)
    at process.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js:109:3)
    at process.EventEmitter.emit (events.js:95:17)
    at process._fatalException (node.js:272:26)

Changing the node-zookeeper reference to use the latest source fixes the issue.
