### PR TITLE
Fix hang in client test

### DIFF
--- a/test/client.test.js
+++ b/test/client.test.js
@@ -63,6 +63,7 @@ test('connect timeout', function (t) {
     t.ok(client);
     client.connect(function (err) {
         t.ok(err);
+        client.close();
         t.end();
     });
 });


### PR DESCRIPTION
If the client from the "connect timeout" test is not closed, the node
process will not exit due to node-zookeeper-client constantly
attempting to connect.
