### PR TITLE
fix bug: error happens if no callback is set when calling client.close()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -195,7 +195,9 @@ ZKClient.prototype.connect = function connect(cb) {
 ZKClient.prototype.close = function close(cb) {
     assert.optionalFunc(cb, 'callback');
 
-    cb = once(cb);
+    if (cb) {
+        cb = once(cb);
+    }
 
     var log = this.log;
     var zk = this.zk;


### PR DESCRIPTION
Hi mcavage, I've encountered a bug when invoking `client.close()`

```
/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/once/once.js:16
    return f.value = fn.apply(this, arguments)
                        ^
TypeError: Cannot call method 'apply' of undefined
    at f (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/once/once.js:16:25)
    at Client.<anonymous> (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/lib/client.js:215:17)
    at Client.f (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/once/once.js:16:25)
    at Client.g (events.js:180:16)
    at Client.emit (events.js:117:20)
    at Client.defaultStateListener (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/node-zookeeper-client/index.js:52:14)
    at Client.emit (events.js:95:17)
    at Client.onConnectionManagerState (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/node-zookeeper-client/index.js:262:14)
    at ConnectionManager.emit (events.js:95:17)
    at ConnectionManager.setState (/Users/laike9m/ICT/ICT_Projects/zk/node_modules/zkplus/node_modules/node-zookeeper-client/lib/ConnectionManager.js:168:14)
```

The reason is clear: In [`lib/client.js` line 198][1]
```
cb = once(cb);
```
and this is what `once` do
```
function once (fn) {
  var f = function () {
    if (f.called) return f.value
    f.called = true
    return f.value = fn.apply(this, arguments)
  }
  f.called = false
  return f
}
```
Therefore, even though cb is undefined, it becomes a function after calling `once(cb)`, so in [line 209][2] and [line 214][3], the `if(cb)` judgement breaks cause it's always true. Then `cb` gets called, but since `fn` is undefiend, ` fn.apply(this, arguments)` raise an error.

I've made the fix so that if `cb` is undefined, `once(cb)` won't be called, and the subsequent judgement won't break.

[1]: https://github.com/mcavage/node-zkplus/blob/master/lib/client.js#L198
[2]: https://github.com/mcavage/node-zkplus/blob/master/lib/client.js#L209
[3]: https://github.com/mcavage/node-zkplus/blob/master/lib/client.js#L214