### PR TITLE
TRITON-1660 32-bit registrar should be buildable on x86_64

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "assert-plus": "0.1.5",
-        "bunyan": "0.23.1",
+        "bunyan": "1.8.12",
         "node-uuid": "1.4.1",
         "once": "1.3.0",
         "vasync": "1.5.0",


### PR DESCRIPTION
With a local instance of zookeeper running, the integration tests passed.

```
$ make test
npm test | ./node_modules/.bin/bunyan

> zkplus@0.4.0 test /home/jcsb/src/j/misc/node-zkplus
> istanbul test test/test.js | ./node_modules/.bin/faucet

✓ constructor tests
✓ setup
✓ connect timeout
✓ mkdirp
✓ creat no options
✓ create: ephemeral
✓ create: sequential
✓ create: ephemeral_sequential
✓ put not exists
✓ put overwrite
✓ get
✓ readdir
✓ update
✓ stat
✓ unlink
✓ getState
✓ toString
✓ teardown
✓ error when closed
✓ setup
✓ heartbeat
✓ stop proxy
✓ start proxy
✓ rewatch
✓ re-ephemeral
✓ teardown
✓ setup
✓ watch (data)
✓ watch (directory)
✓ watch (data+initialData)
✓ watch (directory + initial data)
✓ teardown
# tests 114
# pass  114
```